### PR TITLE
further fixes with communication

### DIFF
--- a/hypervisor/process/terminal/state.go
+++ b/hypervisor/process/terminal/state.go
@@ -40,7 +40,7 @@ func (self *State) HandleMessages() {
 		case msg.TypePrefix_Input:
 			println("-----------TypePrefix_Input")
 			self.UnpackInputEvents(msgType, m[6:])
-			hypervisor.DbusGlobal.PublishTo(self.proc.OutChannelId, m)
+			hypervisor.DbusGlobal.PublishTo(self.proc.OutChannelId, m[4:])
 		case msg.TypePrefix_Terminal: //process to hypervisor messages
 			println("-----------TypePrefix_Terminal")
 		default:

--- a/msg/types_terminal.go
+++ b/msg/types_terminal.go
@@ -13,7 +13,7 @@ Messages from:
 // - terminal resource IDs, destroy determinism
 // - how do we eliminate or abstract resource ids?
 
-const TypePrefix_Terminal uint16 = 0x02 // terminal message prefix
+const TypePrefix_Terminal uint16 = 0x0200 // terminal message prefix
 
 // Process to Hypervisor, input event
 const (

--- a/viewport/events.go
+++ b/viewport/events.go
@@ -37,14 +37,14 @@ func UnpackInputEvents(message []byte) []byte {
 		msg.MustDeserialize(message, &m)
 		onChar(m)
 
-		Terms.Focused.RelayToTask(message)
+		Terms.Focused.RelayToTask(msg.Serialize(msg.TypeChar, message))
 
 	case msg.TypeKey:
 		var m msg.MessageKey
 		msg.MustDeserialize(message, &m)
 		onKey(m)
 
-		Terms.Focused.RelayToTask(message)
+		Terms.Focused.RelayToTask(msg.Serialize(msg.TypeKey, message))
 
 	case msg.TypeFrameBufferSize:
 		// FIXME: BRAD SAYS THIS IS NOT INPUT

--- a/viewport/terminal/terminal.go
+++ b/viewport/terminal/terminal.go
@@ -61,10 +61,9 @@ func (t *Terminal) Clear() {
 func (t *Terminal) RelayToTask(message []byte) {
 	println("(viewport/terminal/terminal.go).RelayToTask(message []byte)")
 
-	// fmt.Printf("\nPubSub Channel After Adding Terminal\n %+v\n",
-	// hypervisor.DbusGlobal.PubsubChannels)
-	// fmt.Printf("\nPubSub Channel After Adding Terminal\n %+v\n",
-
+	// TODO: Added msgType to the RelayToTask but I don't understand the
+	// difference between inputevents and temrinalevents. If the input events
+	// get transmitted here where do temrinalevents relay then?
 	hypervisor.DbusGlobal.PublishTo(t.OutChannelId, message)
 
 	//TODO: have AttachedProcess send SetChar*/SetCursor/etc. back here


### PR DESCRIPTION
- added sender pubsubchannel id as channelId and also 
- filled switch case typeprefix_input because it works with the input events
- changed TypePrefix_Terminal to 0x0200 because then &0xff00 didn't work of course
- added serialization for the message. how else should we have guessed it's type.
NOTE: now the message that is passed to the pubsubchannels are of following form
4bytes for channelId, 2bytes for masked type, all the remaining for the message thus unmasking works now