### PR TITLE
removed automatic inits

### DIFF
--- a/viewport/gl/canvas.go
+++ b/viewport/gl/canvas.go
@@ -39,8 +39,8 @@ var (
 	CurrY float32
 )
 
-func init() {
-	println("(gl/canvas.go).init()")
+func InitCanvas() {
+	println("(gl/canvas.go).InitCanvas()")
 	// one-time setup
 	PrevColor = GrayDark
 	CurrColor = GrayDark

--- a/viewport/gl/menu.go
+++ b/viewport/gl/menu.go
@@ -1,15 +1,10 @@
 package gl
 
 import (
-	"fmt"
 	"github.com/corpusc/viscript/app"
 )
 
 var MainMenu = Menu{}
-
-func init() {
-	fmt.Println("(viewport/gl/menu.go).init()")
-}
 
 type Menu struct {
 	//IsVertical bool // controls which dimension gets divided up for button sizes

--- a/viewport/viewport.go
+++ b/viewport/viewport.go
@@ -24,6 +24,7 @@ var (
 func ViewportInit() {
 	fmt.Println("viewport.ViewportInit()")
 	app.MakeHighlyVisibleLogHeader(app.Name, 15)
+	igl.InitCanvas()
 	// GLFW event handling must run on the main OS thread
 	// See documentation for functions that are only allowed to be called from the main thread.
 	runtime.LockOSThread()

--- a/viscript.go
+++ b/viscript.go
@@ -47,19 +47,18 @@
 package main
 
 import (
-	"fmt"
 	"github.com/corpusc/viscript/hypervisor"
 	// "github.com/corpusc/viscript/rpc/terminalmanager"
 	"github.com/corpusc/viscript/viewport"
 )
 
 func main() {
-	fmt.Printf("Starting...")
+	println("Starting...")
 
 	hypervisor.Init()
 
 	viewport.DebugPrintInputEvents = true //print input events
-	viewport.ViewportInit()               //runtime.LockOSThread()
+	viewport.ViewportInit()               //runtime.LockOSThread(), InitCanvas()
 	viewport.ViewportScreenInit()
 	viewport.InitEvents()
 	viewport.ViewportTerminalsInit() //start the terminal
@@ -68,7 +67,7 @@ func main() {
 	// rpcInstance := terminalmanager.NewRPC()
 	// rpcInstance.Serve()
 
-	fmt.Printf("Start Loop; \n")
+	println("Start Loop;")
 	for viewport.CloseWindow == false {
 		viewport.DispatchEvents() //event channel
 		hypervisor.ProcessTick()  //processes, handle incoming events
@@ -78,7 +77,7 @@ func main() {
 		viewport.SwapDrawBuffer() //with new frame
 	}
 
-	fmt.Printf("Closing down viewport \n")
+	println("Closing down viewport")
 	viewport.ViewportScreenTeardown()
 	hypervisor.HypervisorTeardown()
 }


### PR DESCRIPTION
- Renamed init of canvas.go to InitCanvas and called it in viewport.go because that's the first thing what is called after hypervisor init and didn't want to include internal gl again in the viscript.go, viewport already had igl imported so.
- Removed "fmt" import from viscript because it was only for printf and used println instead.