### PR TITLE
changed dir structure, added md, printing, errors

### DIFF
--- a/rpc/README.md
+++ b/rpc/README.md
@@ -1,0 +1,27 @@
+## Running CLI
+
+In order to be able to run CLI client for viscript RPC server should be running.
+At this point simple RPC server is run using goroutine with the viscript runtime when installing
+and running the viscript:
+
+```
+go install && viscript
+```
+
+Once the server is listening we can just type:
+
+```
+go run rpc/cli/cli.go
+```
+
+And the CLI connects to the RPC server which is ready to serve.
+
+## Running with gotty
+
+You could also try launching `cli.sh` script like:
+
+```
+chmod +x cli.sh
+./cli.sh
+```
+to be able to interact with cli using the web interface (uses gotty).

--- a/rpc/cli/cli.go
+++ b/rpc/cli/cli.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/corpusc/viscript/rpc/cli"
+	cm "github.com/corpusc/viscript/rpc/climanager"
 )
 
-var cliManager cli.CliManager
+var cliManager cm.CliManager
 
 const prompt string = "Enter the command (help(h) for commands list):\n> "
 const defaultPort string = "7777"
@@ -19,8 +19,6 @@ func main() {
 	if len(os.Args) >= 2 {
 		port = os.Args[1]
 	}
-	println("Connecting on port:", port)
-
 	cliManager.Init(port)
 	promptCycle()
 }

--- a/rpc/cli/cli.sh
+++ b/rpc/cli/cli.sh
@@ -1,0 +1,2 @@
+go build
+gotty -w -p 9999 --reconnect ./cli

--- a/rpc/climanager/climanager.go
+++ b/rpc/climanager/climanager.go
@@ -1,6 +1,8 @@
-package cli
+package climanager
 
 import (
+	"os"
+
 	"github.com/corpusc/viscript/msg"
 	tm "github.com/corpusc/viscript/rpc/terminalmanager"
 )
@@ -15,10 +17,18 @@ type CliManager struct {
 }
 
 func (c *CliManager) Init(port string) {
-	c.initCommands()
+	println("Attempting to connect on port:", port)
+	var clienError error
+	c.Client, clienError = tm.RunClient(":" + port)
 
+	if clienError != nil {
+		println(clienError.Error())
+		os.Exit(1)
+	}
+
+	println("Connected!")
+	c.initCommands()
 	c.SessionEnd = false
-	c.Client = tm.RunClient(":" + port)
 }
 
 func (c *CliManager) CommandDispatcher(command string, args []string) {
@@ -68,12 +78,4 @@ func (c *CliManager) commandExists(key string) bool {
 
 func (c *CliManager) PrintServerError(err error) {
 	c.Client.ErrorOut(err)
-}
-
-func (c *CliManager) TerminalIdNotNil() bool {
-	return c.ChosenTerminalId != 0
-}
-
-func (c *CliManager) ProcessIdNotNil() bool {
-	return c.ChosenProcessId != 0
 }

--- a/rpc/climanager/commandfuncs.go
+++ b/rpc/climanager/commandfuncs.go
@@ -1,14 +1,15 @@
-package cli
+package climanager
 
 import (
 	"fmt"
-	"github.com/corpusc/viscript/hypervisor/dbus"
-	"github.com/corpusc/viscript/msg"
-	tm "github.com/corpusc/viscript/rpc/terminalmanager"
 	"os"
 	"os/exec"
 	"runtime"
 	"strconv"
+
+	"github.com/corpusc/viscript/hypervisor/dbus"
+	"github.com/corpusc/viscript/msg"
+	tm "github.com/corpusc/viscript/rpc/terminalmanager"
 )
 
 func (c *CliManager) PrintHelp(_ []string) error {
@@ -27,7 +28,7 @@ func (c *CliManager) PrintHelp(_ []string) error {
 	// p("> lpub\t\tList all publishers. --TODO\n\n")
 	// p("> ld\t\tList all dbus objects. --TODO\n")
 
-	p("> clear(c)\t\tClear the terminal.\n")
+	p("> clear(c)\tClear the terminal.\n")
 	p("> quit(q)\tQuit from cli.\n\n")
 
 	return nil

--- a/rpc/rpc_run.go
+++ b/rpc/rpc_run.go
@@ -1,8 +1,10 @@
 package main
 
-import "github.com/corpusc/viscript/rpc/terminalmanager"
+// Commented because currently rpc server is run inside a goroutine in viscript.go
+// import "github.com/corpusc/viscript/rpc/terminalmanager"
 
-func run() {
-	rpcInstance := terminalmanager.NewRPC()
-	rpcInstance.Serve()
+func main() {
+	println("It should be running with viscript. Try connecting with cli client instead.")
+	// rpcInstance := terminalmanager.NewRPC()
+	// rpcInstance.Serve()
 }

--- a/rpc/terminalmanager/rpc_client.go
+++ b/rpc/terminalmanager/rpc_client.go
@@ -13,14 +13,14 @@ type RPCMessage struct {
 	Arguments []string
 }
 
-func RunClient(addr string) *RPCClient {
+func RunClient(addr string) (*RPCClient, error) {
 	rpcClient := &RPCClient{}
 	client, err := rpc.DialHTTP("tcp", addr)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	rpcClient.Client = client
-	return rpcClient
+	return rpcClient, nil
 }
 
 func (rpcClient *RPCClient) SendToRPC(command string, args []string) ([]byte, error) {
@@ -34,5 +34,5 @@ func (rpcClient *RPCClient) SendToRPC(command string, args []string) ([]byte, er
 }
 
 func (rpcClient *RPCClient) ErrorOut(err error) {
-	println("Error. Server says:", err)
+	println("Error. Server says:\n", err.Error())
 }

--- a/rpc/terminalmanager/rpc_receiver.go
+++ b/rpc/terminalmanager/rpc_receiver.go
@@ -3,9 +3,11 @@ package terminalmanager
 import (
 	"errors"
 	"fmt"
-	"github.com/corpusc/viscript/hypervisor"
-	"github.com/corpusc/viscript/msg"
 	"strconv"
+
+	"github.com/corpusc/viscript/hypervisor"
+	"github.com/corpusc/viscript/hypervisor/dbus"
+	"github.com/corpusc/viscript/msg"
 )
 
 type RPCReceiver struct {
@@ -13,7 +15,8 @@ type RPCReceiver struct {
 }
 
 func (receiver *RPCReceiver) ListTIDsWithProcessIDs(_ []string, result *[]byte) error {
-	println("\nHandling Request: Lis terminal Ids with attached process Ids")
+	println("\nHandling Request: List terminal Ids with attached process Ids")
+
 	terms := receiver.TerminalManager.terminalStack.Terms
 	termsWithProcessIDs := make([]msg.TermAndAttachedProcessID, 0)
 
@@ -21,13 +24,20 @@ func (receiver *RPCReceiver) ListTIDsWithProcessIDs(_ []string, result *[]byte) 
 		termsWithProcessIDs = append(termsWithProcessIDs,
 			msg.TermAndAttachedProcessID{TerminalId: termID, AttachedProcessId: term.AttachedProcess})
 	}
-	fmt.Printf("Terms with process IDs list:%+v\n", termsWithProcessIDs)
+
+	println("[==============================]")
+	println("Terms with process Ids list:")
+	for _, t := range termsWithProcessIDs {
+		println("Terminal Id:", t.TerminalId, "\tAttached Process Id:", t.AttachedProcessId)
+	}
+
 	*result = msg.Serialize(uint16(0), termsWithProcessIDs)
 	return nil
 }
 
 func (receiver *RPCReceiver) GetTermChannelInfo(args []string, result *[]byte) error {
 	println("\nHandling Request: Get terminal out dbus channel info")
+
 	terminalId, err := strconv.Atoi(args[0])
 	if err != nil {
 		fmt.Println(err)
@@ -37,15 +47,15 @@ func (receiver *RPCReceiver) GetTermChannelInfo(args []string, result *[]byte) e
 	term, ok := receiver.TerminalManager.terminalStack.Terms[msg.TerminalId(terminalId)]
 	if !ok {
 		termExistsErrText := fmt.Sprintf("Terminal with given Id: %d doesn't exist.", terminalId)
+		println("[==============!!==============]")
 		fmt.Println(termExistsErrText)
 		return errors.New(termExistsErrText)
 	}
 
-	// We could also get dbusChannel from this terminal's perspective
-	// but out channel should give some useful info I guess
 	dbusChannel, ok := hypervisor.DbusGlobal.PubsubChannels[term.OutChannelId]
 	if !ok {
 		channelExistsErrText := fmt.Sprintf("Channel with given Id: %d doesn't exist.", term.OutChannelId)
+		println("[==============!!==============]")
 		fmt.Println(channelExistsErrText)
 		return errors.New(channelExistsErrText)
 	}
@@ -66,27 +76,52 @@ func (receiver *RPCReceiver) GetTermChannelInfo(args []string, result *[]byte) e
 	}
 
 	channelInfo.Subscribers = channelSubscribers
+	println("[==============================]")
+
+	fmt.Printf("Term (Id: %d) out channel info:\n", terminalId)
+
+	println("Channel Id:", channelInfo.ChannelId)
+	println("Channel Owner:", channelInfo.Owner)
+	println("Channel Owner's Type:", dbus.ResourceTypeNames[channelInfo.OwnerType])
+	println("Channel ResourceIdentifier:", channelInfo.ResourceIdentifier)
+
+	subCount := len(channelInfo.Subscribers)
+
+	if subCount == 0 {
+		fmt.Printf("No subscribers to this channel.\n")
+	} else {
+		fmt.Printf("Channel's Subscribers (%d total):\n\n", subCount)
+		fmt.Println("Index\tResourceId\t\tResource Type")
+		for index, subscriber := range channelInfo.Subscribers {
+			fmt.Println(index, "\t", subscriber.SubscriberId, "\t\t",
+				dbus.ResourceTypeNames[subscriber.SubscriberType])
+		}
+	}
 
 	*result = msg.Serialize(uint16(0), channelInfo)
 	return nil
 }
 
 func (receiver *RPCReceiver) StartTerminalWithProcess(_ []string, result *[]byte) error {
-	println("\nHandling Request: ")
+	println("\nHandling Request: Start terminal with process")
 	terms := receiver.TerminalManager.terminalStack
 	newTerminalID := terms.AddTerminal()
+	println("[==============================]")
 	fmt.Println("Terminal with ID", newTerminalID, "created!")
 	*result = msg.Serialize((uint16)(0), newTerminalID)
 	return nil
 }
 
 func (receiver *RPCReceiver) ListProcessIDs(_ []string, result *[]byte) error {
+	println("\nHandling Request: List all process Ids")
 	processes := receiver.TerminalManager.processList.ProcessMap
 	processIDs := make([]msg.ProcessId, 0)
 
 	for k, _ := range processes {
 		processIDs = append(processIDs, k)
 	}
+
+	println("[==============================]")
 	fmt.Println("Process ID list:", processIDs)
 	*result = msg.Serialize((uint16)(0), processIDs)
 	return nil


### PR DESCRIPTION
- Changed directory structure of cli
- Added README.md to the cli for whoever wants to run it
- Changed printing on both server and client sides
- RPCClient connection refused error is handled now (cli exits)
- Errors coming from the server are now visible in the cli output, thanks to Error() func that returns the error text.
- Added cli.sh script that runs gotty web interface for cli.go