### PR TITLE
more external processes (now builds) [incomplete, todos in viscript.go]

### DIFF
--- a/hypervisor/process/terminal/README.md
+++ b/hypervisor/process/terminal/README.md
@@ -1,3 +1,4 @@
+// TODO: change readme
 ### Running with external process temporarily
 
 1. Please make sure that the GOPATH is properly set and it's on the PATH.

--- a/hypervisor/process/terminal/process.go
+++ b/hypervisor/process/terminal/process.go
@@ -1,20 +1,12 @@
 package process
 
 import (
+	"errors"
+
+	"strconv"
+
 	"github.com/corpusc/viscript/msg"
 )
-
-//non-instanced
-func NewProcess() *Process {
-	println("(process/terminal/process.go).NewProcess()")
-	var p Process
-	p.Id = msg.NextProcessId()
-	p.Type = 0
-	p.Label = "TestLabel"
-	p.InChannel = make(chan []byte, msg.ChannelCapacity)
-	p.State.Init(&p)
-	return &p
-}
 
 type Process struct {
 	Id           msg.ProcessId
@@ -23,6 +15,27 @@ type Process struct {
 	OutChannelId uint32
 	InChannel    chan []byte
 	State        State
+
+	extProcAttached bool
+	extProcessId    msg.ExtProcessId
+	extProcesses    map[msg.ExtProcessId]*ExternalProcess
+}
+
+func NewProcess() *Process {
+	println("(process/terminal/process.go).NewProcess()")
+	var p Process
+	p.Id = msg.NextProcessId()
+	p.Type = 0
+	p.Label = "TestLabel"
+	p.InChannel = make(chan []byte, msg.ChannelCapacity)
+	p.State.Init(&p)
+
+	// means no external process is attached
+	p.extProcAttached = false
+	p.extProcessId = msg.ExtProcessId(0)
+	p.extProcesses = make(map[msg.ExtProcessId]*ExternalProcess)
+
+	return &p
 }
 
 func (pr *Process) GetProcessInterface() msg.ProcessInterface {
@@ -35,6 +48,20 @@ func (pr *Process) DeleteProcess() {
 	close(pr.InChannel)
 	pr.State.proc = nil
 	pr = nil
+}
+
+func (pr *Process) HasExtProcessAttached() bool {
+	return pr.extProcAttached && pr.extProcessId != 0
+}
+
+func (pr *Process) GetAttachedExtProcess() (*ExternalProcess, error) {
+	extProc, ok := pr.extProcesses[pr.extProcessId]
+	if ok {
+		return extProc, nil
+	}
+
+	return nil, errors.New("External process with id " +
+		strconv.Itoa(int(pr.extProcessId)) + " doesn't exist.")
 }
 
 //implement the interface

--- a/hypervisor/process/terminal/state.go
+++ b/hypervisor/process/terminal/state.go
@@ -9,7 +9,6 @@ type State struct {
 	proc                  *Process
 	DebugPrintInputEvents bool
 	Cli                   *Cli
-	CmdOut                chan []byte
 }
 
 func (st *State) Init(proc *Process) {
@@ -17,7 +16,6 @@ func (st *State) Init(proc *Process) {
 	st.proc = proc
 	st.DebugPrintInputEvents = true
 	st.Cli = NewCli()
-	st.CmdOut = make(chan []byte, 1024)
 }
 
 func (st *State) HandleMessages() {

--- a/msg/id.go
+++ b/msg/id.go
@@ -6,6 +6,7 @@ import (
 
 type ProcessId uint64 //HyperVisor: processId
 type TerminalId uint64
+type ExtProcessId uint64
 
 var ProcessIdGlobal ProcessId = 1 //sequential
 

--- a/viscript.go
+++ b/viscript.go
@@ -2,6 +2,12 @@
 
 ------- NEXT THINGS TODO: -------
 
+* ExternalProcess:
+	attach,
+	send to background (https://repl.it/GeGn/1),
+	send to foreground,
+	list jobs (external processes)
+
 * limit resizing to require at least 16 char columns
 
 * make command line dynamic based on terminal's .GridSize


### PR DESCRIPTION
- moved readme and external process source file inside the terminal
- added state to the external process
- added extProcAttached bool to the process so that we know if a particular process behind the viscript term has an attached external process
- added extProcessId to the msg and an instance to the Process also to store the attached external process id, used when getting the desired external process pointer
- added extProcesses map to the Process that is of type map[msg.ExtProcessId]*ExternalProcess and can be used to access the desired external process, switch to it, etc.
- added initialization of above mentioned variables to the NewProcess() implementation
- added HasExtProcessAttached to the Process to know if it has external process attached and if processId variable isn't 0 because 0 means no process is attached
- Added GetAttachedExtProcess to the Process also that also returns error if the process is not found in the map.
- changed actOnCommand func to be able to redirect input to the attached process if it's there and if not handle normal commands, (might need another implementation later, as we decide)
- also if the length of the command is 0 we don't proceed further
- removed cmdOut from the state
- created new ExtProcessId into the msg/id.go same as uint64 just for distinction like ProcessId
- updated viscript with external process TODOs