### PR TITLE
cmd fix and etc...

### DIFF
--- a/hypervisor/process/terminal/msg_actions.go
+++ b/hypervisor/process/terminal/msg_actions.go
@@ -105,6 +105,7 @@ func (st *State) actOnCommand() {
 					for i := 0; i < 5; i++ {
 						println("********* " + err.Error() + " *********")
 					}
+					st.PrintLn(err.Error())
 				}
 			}
 

--- a/hypervisor/process/terminal/task.go
+++ b/hypervisor/process/terminal/task.go
@@ -83,7 +83,7 @@ func (pr *Process) DetachExtProcess() {
 func (pr *Process) AddTaskExternal(tokens []string) (msg.ExtProcessId, error) {
 	app.At(path, "AddTaskExternal")
 
-	newExtProc, err := MakeNewTaskExternal(&pr.State, tokens[0], tokens[1:])
+	newExtProc, err := MakeNewTaskExternal(&pr.State, tokens)
 	if err != nil {
 		return 0, err
 	}

--- a/rpc/climanager/commandfuncs.go
+++ b/rpc/climanager/commandfuncs.go
@@ -47,7 +47,7 @@ func (c *CliManager) ClearTerminal(_ []string) error {
 		cmd.Stdout = os.Stdout
 		cmd.Run()
 	} else if runtimeOs == "windows" {
-		cmd := exec.Command("cls")
+		cmd := exec.Command("cmd", "/C", "cls")
 		cmd.Stdout = os.Stdout
 		cmd.Run()
 	} else {

--- a/viscript.go
+++ b/viscript.go
@@ -2,11 +2,16 @@
 
 ------- NEXT THINGS TODO: -------
 
+* RPC cli:
+	add functionality to print running jobs for a given process id
+	that can be retrieved by lp or setting the process id as default
+	because that already exists
+
 * ExternalProcess:
-	attach,
-	send to background (https://repl.it/GeGn/1),
-	send to foreground,
-	list jobs (external processes)
+	Ctrl + c - detach, delete, kill probably
+	Ctrl + z - detach and let it be running or pause it (https://repl.it/GeGn/1)?,
+	jobs - list all jobs of current terminal
+	fg <id> - send to foreground
 
 * limit resizing to require at least 16 char columns
 


### PR DESCRIPTION
- Added st.PrintLn to the msg_actions because it's nice to see in the viscript terminal why the command didn't succeed to run
- Passing tokens only inside the AddTaskExternal because there was no need, only when on linux
- Changed the implementation and parameters in task_ext
- task_ext InitCmd now checks for runtime operating system
- changed commandfuncs also in the rpc, should be ignored. using new style of calling cls command on windows