### PR TITLE
notes below, exiting, Ctrl+C still unfinished but positives steps taken

### DIFF
--- a/hypervisor/process/terminal/commands.go
+++ b/hypervisor/process/terminal/commands.go
@@ -1,11 +1,12 @@
 package process
 
 import (
+	"strconv"
+	"strings"
+
 	"github.com/corpusc/viscript/hypervisor"
 	extTask "github.com/corpusc/viscript/hypervisor/task_ext"
 	"github.com/corpusc/viscript/msg"
-	"strconv"
-	"strings"
 )
 
 func (st *State) commandStart(args []string) {
@@ -34,7 +35,10 @@ func (st *State) commandStart(args []string) {
 		procId := hypervisor.AddExtProcess(extProcInterface)
 
 		if !detached {
-			st.proc.AttachExternalProcess(extProcInterface)
+			err = st.proc.AttachExternalProcess(extProcInterface)
+			if err != nil {
+				st.PrintLn(err.Error())
+			}
 		}
 
 		st.PrintLn("Added External Process (ID: " +
@@ -64,7 +68,10 @@ func (st *State) commandAttach(args []string) {
 	}
 
 	st.PrintLn(extProc.GetFullCommandLine())
-	st.proc.AttachExternalProcess(extProc)
+	err = st.proc.AttachExternalProcess(extProc)
+	if err != nil {
+		st.PrintLn(err.Error())
+	}
 }
 
 func (st *State) commandListExternalTasks(args []string) {

--- a/hypervisor/process/terminal/msg_actions.go
+++ b/hypervisor/process/terminal/msg_actions.go
@@ -61,6 +61,8 @@ func (st *State) actOnOneTimeHotkeys(m msg.MessageKey) {
 			// }
 			// st.PrintLn("Attached process sent to background.")
 			// st.proc.DetachExternalProcess()
+			st.PrintLn("Detaching External Process")
+			st.proc.DetachExternalProcess()
 		}
 
 	}

--- a/hypervisor/process/terminal/task.go
+++ b/hypervisor/process/terminal/task.go
@@ -54,16 +54,20 @@ func (pr *Process) HasExtProcessAttached() bool {
 	return pr.hasExtProcAttached
 }
 
-func (pr *Process) AttachExternalProcess(extProc msg.ExtProcessInterface) {
+func (pr *Process) AttachExternalProcess(extProc msg.ExtProcessInterface) error {
 	app.At(path, "AttachExternalProcess")
+	err := extProc.Attach()
+	if err != nil {
+		return err
+	}
 	pr.attachedExtProcess = extProc
 	pr.hasExtProcAttached = true
-	pr.attachedExtProcess.Attach()
+	return nil
 }
 
 func (pr *Process) DetachExternalProcess() {
 	app.At(path, "DetachExternalProcess")
-	pr.attachedExtProcess.Detach()
+	// pr.attachedExtProcess.Detach()
 	pr.attachedExtProcess = nil
 	pr.hasExtProcAttached = false
 }
@@ -108,7 +112,7 @@ func (pr *Process) GetIncomingChannel() chan []byte {
 func (pr *Process) Tick() {
 	pr.State.HandleMessages()
 
-	if !pr.hasExtProcAttached {
+	if !pr.HasExtProcessAttached() {
 		return
 	}
 

--- a/hypervisor/task_ext/task_ext_int.go
+++ b/hypervisor/task_ext/task_ext_int.go
@@ -48,15 +48,15 @@ func (pr *ExternalProcess) TearDown() {
 	}
 }
 
-func (pr *ExternalProcess) Attach() {
+func (pr *ExternalProcess) Attach() error {
 	app.At(te, "Attach")
-	pr.detached = false
-	pr.startRoutines()
+	return pr.startRoutines()
 }
 
 func (pr *ExternalProcess) Detach() {
 	app.At(te, "Detach")
-	pr.detached = true
+	// TODO: detach using channels maybe
+	pr.stopRoutines()
 }
 
 func (pr *ExternalProcess) GetId() msg.ExtProcessId {

--- a/msg/interfaces.go
+++ b/msg/interfaces.go
@@ -14,7 +14,7 @@ type ProcessInterface interface {
 type ExtProcessInterface interface {
 	Tick()
 	Start() error
-	Attach()
+	Attach() error
 	Detach()
 	TearDown()
 	GetId() ExtProcessId


### PR DESCRIPTION
- AttachExternalProcess now returns an error
- DetachExternalProcess Ctrl+Z works sort of still experimental
- Attaching is also experimental there might still be some edge cases that we have to think about/consider
- Introduced a new flag inside external task routinesStarted tells if goroutines are already started for this process to not restart them again